### PR TITLE
Deduplicate test fixture variables using shared symlink

### DIFF
--- a/shared/helpers.tofu
+++ b/shared/helpers.tofu
@@ -2,5 +2,5 @@
 # https://github.com/osinfra-io/pt-arche-core-helpers
 
 module "core_helpers" {
-  source = "github.com/osinfra-io/pt-arche-core-helpers//child?ref=70c1e4f4a11acdcfc36055bdd3aa16579d4203a1"  # v0.3.1
+  source = "github.com/osinfra-io/pt-arche-core-helpers//child?ref=70c1e4f4a11acdcfc36055bdd3aa16579d4203a1" # v0.3.1
 }

--- a/tests/fixtures/default/dns/variables.tofu
+++ b/tests/fixtures/default/dns/variables.tofu
@@ -1,14 +1,1 @@
-# Input Variables
-# https://opentofu.org/docs/language/values/variables
-
-variable "environment" {
-  description = "The environment name for the deployment"
-
-  type = string
-}
-
-variable "project" {
-  description = "The Google Cloud project ID"
-
-  type = string
-}
+../shared/variables.tofu

--- a/tests/fixtures/default/regional/variables.tofu
+++ b/tests/fixtures/default/regional/variables.tofu
@@ -1,14 +1,1 @@
-# Input Variables
-# https://opentofu.org/docs/language/values/variables
-
-variable "environment" {
-  description = "The environment name for the deployment"
-
-  type = string
-}
-
-variable "project" {
-  description = "The Google Cloud project ID"
-
-  type = string
-}
+../shared/variables.tofu

--- a/tests/fixtures/default/shared/variables.tofu
+++ b/tests/fixtures/default/shared/variables.tofu
@@ -1,0 +1,14 @@
+# Input Variables
+# https://opentofu.org/docs/language/values/variables
+
+variable "environment" {
+  description = "The environment name for the deployment"
+
+  type = string
+}
+
+variable "project" {
+  description = "The Google Cloud project ID"
+
+  type = string
+}


### PR DESCRIPTION
`tests/fixtures/default/regional/variables.tofu` and `tests/fixtures/default/dns/variables.tofu` were byte-for-byte identical. Moved the canonical copy to `tests/fixtures/default/shared/variables.tofu` and replaced both with relative symlinks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Consolidated shared fixture configuration for deployment environment and project inputs.
  * Updated test scenarios to use common configuration values, improving consistency across DNS and regional fixtures.

* **Style**
  * Applied a minor formatting cleanup to an internal configuration comment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->